### PR TITLE
Update for the latest version of Platypus (5.3)

### DIFF
--- a/End-user Read Me.rtf
+++ b/End-user Read Me.rtf
@@ -17,7 +17,7 @@ http://www.timdoug.com/\
 \b\fs30 a quick and simple .(m)pkg extractor\
 
 \b0\fs24 \
-for Mac OS X 10.4+, PPC/Intel\
+for Mac OS X 10.8+, Intel 64-bit\
 released under the GNU GPL (see COPYING)\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\ql\qnatural\pardirnatural
 \cf0 \

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ VERSION:
 	@exit 1
 
 unpkg.app: unpkg.py VERSION
-	/usr/local/bin/platypus -DR -a unpkg -o 'Progress Bar' \
+	/usr/local/bin/platypus -D -a unpkg -o 'Progress Bar' \
 -p /usr/bin/python -n 'LucidaGrande 12' \
--V ${VERSION} -s upkg -I org.timdoug.unpkg -u timdoug -X '*' -T '****|fold' \
+-V ${VERSION} -I org.timdoug.unpkg -u timdoug -X 'pkg|mpkg' -T 'com.apple.installer-package|com.apple.installer-meta-package|com.apple.installer-package-archive' \
 -i appIcon.icns -f xar -f cpio -y -c unpkg.py unpkg.app
 
 zip: unpkg.app


### PR DESCRIPTION
- Updates Platypus command line arguments to work with Platypus version 5.3 (to stop macOS 10.12+ from complaining that the former 32-bit app is out-of-date).
- Specifically uses the macOS Installer package UTIs, so unpkg shows up in packages' "Open With" Finder menu.
- Updates end-user readme to the Platypus stub's current system requirements.